### PR TITLE
add copy tsv button + logic at module function call level

### DIFF
--- a/report-visualizer.html
+++ b/report-visualizer.html
@@ -243,7 +243,76 @@
         html += '</ul></div>';
         html += '</div>';
       });
+      // add download button for csv
+      html += '<button id="download-csv-btn" class="filter-btn" style="margin-bottom: 1em;">Download CSV</button>'
       viz.innerHTML = html;
+
+      // add event listener for download button
+      document.getElementById('download-csv-btn').addEventListener('click', () => {
+      if (!currentData || !currentData.detected_usages) return ;
+
+      // placeholders, to give idea of what to enter
+      const product = prompt("Enter Product Name:", "OpenShift API Server");
+      const repo = prompt("Enter Repository URL:", "https://github.com/example/repo");
+      const entrypoint = prompt("Enter Entrypoint Path:", "cmd/example/main.go");
+
+      if (!product || !repo || !entrypoint) {
+        alert("All metadata fields are required.");
+        return;
+      }
+
+      const csvRows = [
+        ["Product", "Repository", "Entrypoint", "Crypto module", "Function called", "Status", "Comment", "Dependency Graph"]
+      ];
+
+      const usages = currentData.detected_usages.slice().sort((a, b) => a.function.localeCompare(b.function));
+
+      usages.forEach((usage, index) => {
+        const row = Array(8).fill("");
+
+        // First entry gets metadata
+        if (index === 0) {
+          row[0] = product;
+          row[1] = repo;
+          row[2] = entrypoint;
+        }
+
+        row[3] = usage.package || "";
+        row[4] = usage.function || "";
+        // row[5] and row[6] left blank for Status and Comment
+        row[7] = buildDependencyGraphJS(usage.call_tree);
+
+        csvRows.push(row);
+      });
+
+      const csvContent = csvRows.map(e => e.map(cell => `"${(cell || "").replace(/"/g, '""')}"`).join(",")).join("\n");
+      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+
+      const downloadLink = document.createElement("a");
+      downloadLink.href = URL.createObjectURL(blob);
+      // extract file name from fileNameDiv.
+      const fileNameRaw = fileNameDiv.textContent.replace(/^Loaded file:\s*/, '');
+      // take file name from earlier and remove .json suffix, use as prefix for csv file.
+      downloadLink.download = fileNameRaw.slice(0, -5) + ".csv";
+      downloadLink.style.display = "none";
+      document.body.appendChild(downloadLink);
+      downloadLink.click();
+      document.body.removeChild(downloadLink);
+    });
+
+    function buildDependencyGraphJS(callTree) {
+      if (!Array.isArray(callTree) || callTree.length === 0) return "";
+      return callTree.map(node => {
+        const func = extractFunctionNameJS(node.function);
+        return `${node.package_path}.${func}`;
+      }).join(" -> ");
+    }
+
+    function extractFunctionNameJS(full) {
+      if (!full) return "";
+      const parts = full.split(".");
+      return parts[parts.length - 1];
+    }
 
       // Add click listeners for call-labels
       document.querySelectorAll('.call-label').forEach(el => {

--- a/report-visualizer.html
+++ b/report-visualizer.html
@@ -147,6 +147,8 @@
     </div>
   <div id="visualization"></div>
   <script>
+    // track copies of modules - so module name isn't constantly copied over
+    window._moduleCopyCount = {};
     const dropZone = document.getElementById('drop-zone');
     const viz = document.getElementById('visualization');
     const filterIndicator = document.getElementById('filter-indicator');
@@ -232,8 +234,14 @@
                 html += `<span class="call-arrow">→</span>`;
               }
               html += `<span class="call-label" title="Package: ${node.package_path}" data-package="${node.package_path}">${node.function}</span>`;
-              if (index === d.call_tree.length - 1) {
-                html += `<span class='copy-call-tree-btn' title='Copy call tree' style='margin-left:0.4em;vertical-align:middle;cursor:pointer;display:inline-block;'>📋</span><span class='copy-confirm' style='display:none;margin-left:0.4em;color:#27ae60;font-size:0.95em;'>Copied!</span>`;
+              if (index === d.call_tree.length - 1) { // replaces call graph copy with tab separated values (TSV) copy for excel sheet
+                html += `
+                        <span 
+                          class='copy-single-usage-btn' 
+                          title='Copy usage to spreadsheet' 
+                          style='margin-left:0.4em;cursor:pointer;display:inline-block;'>📋</span>
+                        <span class='copy-confirm' style='display:none;margin-left:0.4em;color:#27ae60;font-size:0.95em;'>Copied!</span>
+                      `;
               }
             });
             html += `</div></div>`;
@@ -243,62 +251,53 @@
         html += '</ul></div>';
         html += '</div>';
       });
-      // add download button for csv
-      html += '<button id="download-csv-btn" class="filter-btn" style="margin-bottom: 1em;">Download CSV</button>'
       viz.innerHTML = html;
 
-      // add event listener for download button
-      document.getElementById('download-csv-btn').addEventListener('click', () => {
-      if (!currentData || !currentData.detected_usages) return ;
+      // Add click listeners for copy-single-usage-btn
+      document.querySelectorAll('.copy-single-usage-btn').forEach(btn => {
+        btn.addEventListener('click', function(e) {
+          e.stopPropagation();
 
-      // placeholders, to give idea of what to enter
-      const product = prompt("Enter Product Name:", "OpenShift API Server");
-      const repo = prompt("Enter Repository URL:", "https://github.com/example/repo");
-      const entrypoint = prompt("Enter Entrypoint Path:", "cmd/example/main.go");
+          const li = btn.closest('li');
+          const usage = {
+            function: li.querySelector('b')?.textContent || "",
+            caller: li.textContent.match(/called by (.*?) \(/)?.[1] || "",
+            callSite: li.textContent.match(/\((.*?),/)?.[1] || "",
+            packagePath: li.textContent.match(/,\s(.*?)\)/)?.[1] || "",
+            module: li.closest('.group')?.querySelector('.module')?.textContent.match(/Module:\s(.*?)\s\(/)?.[1] || "",
+            callTree: []
+          };
 
-      if (!product || !repo || !entrypoint) {
-        alert("All metadata fields are required.");
-        return;
-      }
+          const callLabels = li.querySelectorAll('.call-label');
+          callLabels.forEach(el => {
+            usage.callTree.push(el.getAttribute('data-package') + "." + el.textContent);
+          });
 
-      const csvRows = [
-        ["Product", "Repository", "Entrypoint", "Crypto module", "Function called", "Status", "Comment", "Dependency Graph"]
-      ];
+          // Track if this is first copy for the module
+          const moduleKey = usage.module;
+          const isFirstInModule = !window._moduleCopyCount[moduleKey];
+          window._moduleCopyCount[moduleKey] = (window._moduleCopyCount[moduleKey] || 0) + 1;
 
-      const usages = currentData.detected_usages.slice().sort((a, b) => a.function.localeCompare(b.function));
+          const fields = [
+            "", // product
+            "", // repo
+            "", // entrypoint
+            isFirstInModule ? usage.module : "",  // Include module only once
+            usage.function,
+            "", // Status
+            "", // Comment
+            usage.callTree.join(" -> ")
+          ];
 
-      usages.forEach((usage, index) => {
-        const row = Array(8).fill("");
+          const tabSeparated = fields.map(f => f.replace(/\t/g, " ")).join("\t");
 
-        // First entry gets metadata
-        if (index === 0) {
-          row[0] = product;
-          row[1] = repo;
-          row[2] = entrypoint;
-        }
-
-        row[3] = usage.package || "";
-        row[4] = usage.function || "";
-        // row[5] and row[6] left blank for Status and Comment
-        row[7] = buildDependencyGraphJS(usage.call_tree);
-
-        csvRows.push(row);
+          navigator.clipboard.writeText(tabSeparated).then(() => {
+            const confirm = btn.nextElementSibling;
+            confirm.style.display = 'inline';
+            setTimeout(() => { confirm.style.display = 'none'; }, 1200);
+          });
+        });
       });
-
-      const csvContent = csvRows.map(e => e.map(cell => `"${(cell || "").replace(/"/g, '""')}"`).join(",")).join("\n");
-      const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
-
-      const downloadLink = document.createElement("a");
-      downloadLink.href = URL.createObjectURL(blob);
-      // extract file name from fileNameDiv.
-      const fileNameRaw = fileNameDiv.textContent.replace(/^Loaded file:\s*/, '');
-      // take file name from earlier and remove .json suffix, use as prefix for csv file.
-      downloadLink.download = fileNameRaw.slice(0, -5) + ".csv";
-      downloadLink.style.display = "none";
-      document.body.appendChild(downloadLink);
-      downloadLink.click();
-      document.body.removeChild(downloadLink);
-    });
 
     function buildDependencyGraphJS(callTree) {
       if (!Array.isArray(callTree) || callTree.length === 0) return "";


### PR DESCRIPTION
As suggested by @dusk125 in conversation, the replacement of the `Copy` button at function call level with logic to convert the module function call into tab separated values (TSV) format, has been completed in this PR. 

This new addition makes it convenient to copy the function call over to a spreadsheet to track x/crypto usage, making the process less tedious while allowing the developer to manually check every call before copying it over.

**HOW TO TEST** : 

1. Open `report-visualiser.html`.
<img width="1475" height="239" alt="image" src="https://github.com/user-attachments/assets/e86026a0-fc1f-437f-acc8-e21337b73696" />
2. Drop in a JSON report.
<img width="949" height="531" alt="image" src="https://github.com/user-attachments/assets/d893b2b0-cc7e-4751-909f-4d88da3b035c" />
3. Open a module.
<img width="966" height="249" alt="image" src="https://github.com/user-attachments/assets/526309ff-4606-4066-ab09-6615faae862f" />
4. Copy one of the function calls using the `📋` button, and paste it into an excel sheet, selecting the first column.
<img width="1005" height="103" alt="image" src="https://github.com/user-attachments/assets/15e0a946-01e5-4f71-8155-64d08420ca13" />
5. You should see the module name has been included in the copy. Now, try step 4 again.
<img width="969" height="79" alt="image" src="https://github.com/user-attachments/assets/25990779-9c56-4f55-a1f6-99da08d6fec0" />
6. You should now see the module name is not included. Perform step 4 and 5 on different modules to ensure the same behaviour is observed. 